### PR TITLE
Bug fix for reading aws regions from the profile config file

### DIFF
--- a/src/rofehcloud/agent.py
+++ b/src/rofehcloud/agent.py
@@ -281,7 +281,7 @@ def setup_services(profile_data: dict):
             )
             aws_regions = None
             if (
-                profile_data["aws_regions_with_resources"]
+                "aws_regions_with_resources" in profile_data
                 and len(profile_data["aws_regions_with_resources"]) > 0
             ):
                 aws_regions = profile_data["aws_regions_with_resources"]


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in the `setup_services` function where the existence of `aws_regions_with_resources` in the `profile_data` dictionary was not checked correctly.
- Improved the conditional logic to ensure the key is present before accessing its value.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.py</strong><dd><code>Fix bug in AWS regions configuration check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rofehcloud/agent.py

<li>Fixed a bug in checking the existence of <code>aws_regions_with_resources</code> in <br><code>profile_data</code>.<br> <li> Changed the condition to check for the key's presence in the <br>dictionary.<br>


</details>


  </td>
  <td><a href="https://github.com/rofehcloud/rofehcloud/pull/13/files#diff-29dd5faf2d5364fbdac483008c781a9d7762d10efa3ed8a6eb2b1d4fea01f66a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information